### PR TITLE
Refactored and made loading of master key bytes more robust

### DIFF
--- a/DIGNDB.App.SmitteStop.API/Services/AnonymousTokenKeySource.cs
+++ b/DIGNDB.App.SmitteStop.API/Services/AnonymousTokenKeySource.cs
@@ -61,7 +61,8 @@ namespace DIGNDB.App.SmitteStop.API.Services
         private RollingKeyPairGenerator CreateKeyPairGenerator()
         {
             var masterCertificate = LocateLocalCertificate(_config.CertificateThumbPrint);
-            return new RollingKeyPairGenerator(masterCertificate, ECParameters);
+            var masterKeyBytes = new CertificatePrivateKeyBytesLoader().ExtractPrivateKeyBytes(masterCertificate);
+            return new RollingKeyPairGenerator(masterKeyBytes, ECParameters);
         }
 
         private static X509Certificate2 LocateLocalCertificate(string thumbprint)

--- a/DIGNDB.App.SmitteStop.API/Services/CertificatesPrivateKeyBytesLoader.cs
+++ b/DIGNDB.App.SmitteStop.API/Services/CertificatesPrivateKeyBytesLoader.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+
+namespace DIGNDB.App.SmitteStop.API.Services
+{
+    public class CertificatePrivateKeyBytesLoader
+    {
+        private readonly PbeParameters _pbeParameters;
+
+        public CertificatePrivateKeyBytesLoader()
+        {
+            _pbeParameters = new PbeParameters(PbeEncryptionAlgorithm.Aes256Cbc, HashAlgorithmName.SHA512, 1);
+        }
+
+        public byte[] ExtractPrivateKeyBytes(X509Certificate2 certificate)
+        {
+            using var ecdsaPrivateKey = certificate.GetECDsaPrivateKey();
+            if (ecdsaPrivateKey != null)
+            {
+                return PlaintextExportParametersIncludingPrivateRegardlessOfExportPolicy(ecdsaPrivateKey).D;
+            }
+
+            var rsaPrivateKey = certificate.GetRSAPrivateKey();
+            if (rsaPrivateKey != null)
+            {
+                var rsaParams = PlaintextExportParametersIncludingPrivateRegardlessOfExportPolicy(rsaPrivateKey);
+                return rsaParams.D.Concat(rsaParams.P).Concat(rsaParams.Q).ToArray();
+            }
+
+            throw new CertificatePrivateKeyBytesLoaderException($"Unsupported private key for certificate {certificate.Thumbprint}");
+        }
+
+        private ECParameters PlaintextExportParametersIncludingPrivateRegardlessOfExportPolicy(ECDsa ecdsaKey)
+        {
+            if (ecdsaKey is ECDsaCng ecdsaCng && CngKeyNeedsPlaintextWorkaround(ecdsaCng.Key))
+            {
+                EnsureCanBeExported(ecdsaCng.Key);
+
+                // Workaround if AllowExport is set, but missing AllowPlaintextExport
+                var password = Encoding.UTF8.GetBytes(Guid.NewGuid().ToString());
+                var exportedKey = ecdsaKey.ExportEncryptedPkcs8PrivateKey(password, _pbeParameters);
+                using var tmpEcdsaKey = ECDsa.Create() ?? throw new CertificatePrivateKeyBytesLoaderException("Unable to create an instance of the default ECDsa implementation");
+                tmpEcdsaKey.ImportEncryptedPkcs8PrivateKey(password, exportedKey, out _);
+                return tmpEcdsaKey.ExportParameters(true);
+            }
+
+            return ecdsaKey.ExportParameters(true);
+        }
+
+        private RSAParameters PlaintextExportParametersIncludingPrivateRegardlessOfExportPolicy(RSA rsaKey)
+        {
+            if (rsaKey is RSACng rsaCng && CngKeyNeedsPlaintextWorkaround(rsaCng.Key))
+            {
+                EnsureCanBeExported(rsaCng.Key);
+
+                // Workaround if AllowExport is set, but missing AllowPlaintextExport
+                var password = Encoding.UTF8.GetBytes(Guid.NewGuid().ToString());
+                var exportedKey = rsaKey.ExportEncryptedPkcs8PrivateKey(password, _pbeParameters);
+                using var tmpRsaKey = RSA.Create() ?? throw new CertificatePrivateKeyBytesLoaderException("Unable to create an instance of the default RSA implementation");
+                tmpRsaKey.ImportEncryptedPkcs8PrivateKey(password, exportedKey, out _);
+                return tmpRsaKey.ExportParameters(true);
+            }
+
+            return rsaKey.ExportParameters(true);
+        }
+
+        private static bool CngKeyNeedsPlaintextWorkaround(CngKey cngKey)
+        {
+            return !cngKey.ExportPolicy.HasFlag(CngExportPolicies.AllowPlaintextExport);
+        }
+
+        private static void EnsureCanBeExported(CngKey cngKey)
+        {
+            if (!cngKey.ExportPolicy.HasFlag(CngExportPolicies.AllowExport))
+            {
+                throw new CertificatePrivateKeyBytesLoaderException("Certificate export policy does not allow export of private key");
+            }
+        }
+    }
+
+    public class CertificatePrivateKeyBytesLoaderException : Exception
+    {
+        public CertificatePrivateKeyBytesLoaderException(string message) : base(message)
+        {
+
+        }
+    }
+}

--- a/DIGNDB.App.SmitteStop.API/Services/RollingKeyPairGenerator.cs
+++ b/DIGNDB.App.SmitteStop.API/Services/RollingKeyPairGenerator.cs
@@ -6,8 +6,6 @@ using Org.BouncyCastle.Crypto.Parameters;
 using Org.BouncyCastle.Math;
 using System;
 using System.Linq;
-using System.Security.Cryptography.X509Certificates;
-using System.Text;
 
 namespace DIGNDB.App.SmitteStop.API.Services
 {
@@ -21,29 +19,6 @@ namespace DIGNDB.App.SmitteStop.API.Services
         {
             _masterKeyBytes = masterKeyBytes;
             ECParameters = ecParameters;
-        }
-
-        public RollingKeyPairGenerator(X509Certificate2 certificate, X9ECParameters ecParameters)
-            : this(RetrievePrivateKeyBytes(certificate), ecParameters)
-        {
-        }
-
-        private static byte[] RetrievePrivateKeyBytes(X509Certificate2 certificate)
-        {
-            var ecdsaPrivateKey = certificate.GetECDsaPrivateKey();
-            if (ecdsaPrivateKey != null)
-            {
-                return ecdsaPrivateKey.ExportParameters(true).D;
-            }
-
-            var rsaPrivateKey = certificate.GetRSAPrivateKey();
-            if (rsaPrivateKey != null)
-            {
-                // TODO: find a better way to extract bytes for RSA key
-                return Encoding.UTF8.GetBytes(rsaPrivateKey.ToXmlString(true));
-            }
-
-            throw new NotSupportedException($"Unsupported private key for certificate {certificate.Thumbprint}");
         }
 
         public BigInteger GetPrivateKey(long keyId)


### PR DESCRIPTION
Extended logic for loading the master key bytes from a certificate to include a workaround for loading certificates lacking the ExportPolicy flag "AllowPlaintextExport" due to the [issue discussed here.](https://docs.microsoft.com/en-us/answers/questions/280592/ncrypt-allow-plaintext-export-flag-removed-during.html)